### PR TITLE
Wait for canary RS to have ready replicas before shifting labels

### DIFF
--- a/rollout/service.go
+++ b/rollout/service.go
@@ -126,6 +126,9 @@ func (c *rolloutContext) reconcileStableAndCanaryService() error {
 	if c.rollout.Spec.Strategy.Canary == nil {
 		return nil
 	}
+	if c.newRS.Status.ReadyReplicas == 0 {
+		return nil
+	}
 	if c.rollout.Spec.Strategy.Canary.StableService != "" && c.stableRS != nil {
 		svc, err := c.servicesLister.Services(c.rollout.Namespace).Get(c.rollout.Spec.Strategy.Canary.StableService)
 		if err != nil {


### PR DESCRIPTION
- When using canary-by-header, it can result in sending traffic prematurly to the canary pods